### PR TITLE
Implementation of Data Loader

### DIFF
--- a/ormconfig.json
+++ b/ormconfig.json
@@ -6,7 +6,7 @@
    "password": "abc12345",
    "database": "quiz-backend",
    "synchronize": false,
-   "logging": false,
+   "logging": true,
    "entities": [
       "src/entity/**/*.ts"
    ],

--- a/src/data-loader/CategoryLoader.ts
+++ b/src/data-loader/CategoryLoader.ts
@@ -1,0 +1,22 @@
+import * as DataLoader from "dataloader";
+import { Category } from "../entity/Category";
+import { ICategoryRepo } from "../interfaces/ICategoryRepo";
+import { container } from "../inversify.config";
+import { TYPES } from "../types/types";
+
+const categoryBatch = async (keys: number[]): Promise<Category[]> => {
+    const categoryRepo = container.get<ICategoryRepo>(TYPES.ICategoryRepo);
+    const categories = await categoryRepo.findByIds(keys);
+
+    const catMap: {
+        [key: number]: Category;
+    } = {};
+    categories.forEach((catObj) => {
+        catMap[catObj.id] = catObj;
+    });
+
+    return keys.map((key) => catMap[key]);
+};
+
+export const CategoryLoader = () =>
+    new DataLoader<number, Category>(categoryBatch);

--- a/src/data-loader/DifficultyLoader.ts
+++ b/src/data-loader/DifficultyLoader.ts
@@ -1,0 +1,26 @@
+import * as DataLoader from "dataloader";
+import { Difficulty } from "../entity/Difficulty";
+import { IDifficultyRepo } from "../interfaces/IDifficultyRepo";
+import { container } from "../inversify.config";
+import { TYPES } from "../types/types";
+
+const difficultyBatch = async (keys: number[]): Promise<Difficulty[]> => {
+    const difficultyRepo = container.get<IDifficultyRepo>(
+        TYPES.IDifficultyRepo
+    );
+
+    const difficulties = await difficultyRepo.findByIds(keys);
+
+    const diffMap: {
+        [key: number]: Difficulty;
+    } = {};
+
+    difficulties.forEach((diffObj) => {
+        diffMap[diffObj.id] = diffObj;
+    });
+
+    return keys.map((key) => diffMap[key]);
+};
+
+export const DifficultyLoader = () =>
+    new DataLoader<number, Difficulty>(difficultyBatch);

--- a/src/data-loader/QuestionAnswersLoader.ts
+++ b/src/data-loader/QuestionAnswersLoader.ts
@@ -1,0 +1,20 @@
+import * as DataLoader from "dataloader";
+import { Answer } from "../entity/Answer";
+import { Question } from "../entity/Question";
+
+const answersBatch = async (keys: number[]): Promise<Answer[][]> => {
+    const questions = await Question.createQueryBuilder("question")
+        .leftJoinAndSelect("question.answers", "answer")
+        .where("question.id in (:...keys)", { keys })
+        .getMany();
+    const questionMap: { [key: number]: Answer[] } = {};
+
+    questions.map((question) => {
+        questionMap[question.id] = question.answers;
+    });
+
+    return keys.map((key) => questionMap[key]);
+};
+
+export const QuestionAnswersLoader = () =>
+    new DataLoader<number, Answer[]>(answersBatch);

--- a/src/data-loader/QuestionAnswersLoader.ts
+++ b/src/data-loader/QuestionAnswersLoader.ts
@@ -1,12 +1,13 @@
 import * as DataLoader from "dataloader";
 import { Answer } from "../entity/Answer";
-import { Question } from "../entity/Question";
+import { IQuestionRepo } from "../interfaces/IQuestionRepo";
+import { container } from "../inversify.config";
+import { TYPES } from "../types/types";
 
 const answersBatch = async (keys: number[]): Promise<Answer[][]> => {
-    const questions = await Question.createQueryBuilder("question")
-        .leftJoinAndSelect("question.answers", "answer")
-        .where("question.id in (:...keys)", { keys })
-        .getMany();
+    const questionRepo = container.get<IQuestionRepo>(TYPES.IQuestionRepo);
+    const questions = await questionRepo.findByIdsWithAnswers(keys);
+
     const questionMap: { [key: number]: Answer[] } = {};
 
     questions.map((question) => {

--- a/src/data-loader/QuestionsLoader.ts
+++ b/src/data-loader/QuestionsLoader.ts
@@ -1,0 +1,14 @@
+import * as DataLoader from "dataloader";
+import { Question } from "../entity/Question";
+import { Quiz } from "../entity/Quiz";
+
+const questionsBatch = async (keys: number[]): Promise<Question[][]> => {
+    const quizzes = await Quiz.createQueryBuilder("quiz")
+        .leftJoinAndSelect("quiz.questions", "question")
+        .where("quiz.id in (:...keys)", { keys })
+        .getMany();
+    return quizzes.map((quiz) => quiz.questions);
+};
+
+export const QuestionsLoader = () =>
+    new DataLoader<number, Question[]>(questionsBatch);

--- a/src/data-loader/QuizLoader.ts
+++ b/src/data-loader/QuizLoader.ts
@@ -1,0 +1,20 @@
+import * as DataLoader from "dataloader";
+import { Quiz } from "../entity/Quiz";
+import { IQuizRepo } from "../interfaces/IQuizRepo";
+import { container } from "../inversify.config";
+import { TYPES } from "../types/types";
+
+const quizBatch = async (keys: number[]): Promise<Quiz[]> => {
+    const quizRepo = container.get<IQuizRepo>(TYPES.IQuizRepo);
+
+    const quizzes = await quizRepo.findByIds(keys);
+
+    const quizMap: { [key: number]: Quiz } = {};
+    quizzes.forEach((quiz) => {
+        quizMap[quiz.id] = quiz;
+    });
+
+    return keys.map((key) => quizMap[key]);
+};
+
+export const QuizLoader = () => new DataLoader<number, Quiz>(quizBatch);

--- a/src/data-loader/QuizQuestionsLoader.ts
+++ b/src/data-loader/QuizQuestionsLoader.ts
@@ -1,12 +1,12 @@
 import * as DataLoader from "dataloader";
 import { Question } from "../entity/Question";
-import { Quiz } from "../entity/Quiz";
+import { IQuizRepo } from "../interfaces/IQuizRepo";
+import { container } from "../inversify.config";
+import { TYPES } from "../types/types";
 
 const questionsBatch = async (keys: number[]): Promise<Question[][]> => {
-    const quizzes = await Quiz.createQueryBuilder("quiz")
-        .leftJoinAndSelect("quiz.questions", "question")
-        .where("quiz.id in (:...keys)", { keys })
-        .getMany();
+    const quizRepo = container.get<IQuizRepo>(TYPES.IQuizRepo);
+    const quizzes = await quizRepo.findByIdsWithQuestions(keys);
 
     const quizMap: { [key: number]: Question[] } = {};
     quizzes.forEach((quiz) => {

--- a/src/data-loader/QuizQuestionsLoader.ts
+++ b/src/data-loader/QuizQuestionsLoader.ts
@@ -7,8 +7,14 @@ const questionsBatch = async (keys: number[]): Promise<Question[][]> => {
         .leftJoinAndSelect("quiz.questions", "question")
         .where("quiz.id in (:...keys)", { keys })
         .getMany();
-    return quizzes.map((quiz) => quiz.questions);
+
+    const quizMap: { [key: number]: Question[] } = {};
+    quizzes.forEach((quiz) => {
+        quizMap[quiz.id] = quiz.questions;
+    });
+
+    return keys.map((key) => quizMap[key]);
 };
 
-export const QuestionsLoader = () =>
+export const QuizQuestionsLoader = () =>
     new DataLoader<number, Question[]>(questionsBatch);

--- a/src/data-loader/SubmissionAnswersLoader.ts
+++ b/src/data-loader/SubmissionAnswersLoader.ts
@@ -1,6 +1,5 @@
 import * as DataLoader from "dataloader";
 import { Answer } from "../entity/Answer";
-import { Submission } from "../entity/Submission";
 import { ISubmissionRepo } from "../interfaces/ISubmissionRepo";
 import { container } from "../inversify.config";
 import { TYPES } from "../types/types";

--- a/src/data-loader/SubmissionAnswersLoader.ts
+++ b/src/data-loader/SubmissionAnswersLoader.ts
@@ -1,12 +1,15 @@
 import * as DataLoader from "dataloader";
 import { Answer } from "../entity/Answer";
 import { Submission } from "../entity/Submission";
+import { ISubmissionRepo } from "../interfaces/ISubmissionRepo";
+import { container } from "../inversify.config";
+import { TYPES } from "../types/types";
 
 const answersBatch = async (keys: number[]): Promise<Answer[][]> => {
-    const submissions = await Submission.createQueryBuilder("submission")
-        .leftJoinAndSelect("submission.answers", "answer")
-        .where("submission.id in (:...keys)", { keys })
-        .getMany();
+    const submissionRepo = container.get<ISubmissionRepo>(
+        TYPES.ISubmissionRepo
+    );
+    const submissions = await submissionRepo.findByIdsWithAnswers(keys);
     const subMap: { [key: number]: Answer[] } = {};
     submissions.forEach((sub) => {
         subMap[sub.id] = sub.answers;

--- a/src/data-loader/SubmissionAnswersLoader.ts
+++ b/src/data-loader/SubmissionAnswersLoader.ts
@@ -1,0 +1,19 @@
+import * as DataLoader from "dataloader";
+import { Answer } from "../entity/Answer";
+import { Submission } from "../entity/Submission";
+
+const answersBatch = async (keys: number[]): Promise<Answer[][]> => {
+    const submissions = await Submission.createQueryBuilder("submission")
+        .leftJoinAndSelect("submission.answers", "answer")
+        .where("submission.id in (:...keys)", { keys })
+        .getMany();
+    const subMap: { [key: number]: Answer[] } = {};
+    submissions.forEach((sub) => {
+        subMap[sub.id] = sub.answers;
+    });
+
+    return keys.map((key) => subMap[key]);
+};
+
+export const SubmissionAnswersLoader = () =>
+    new DataLoader<number, Answer[]>(answersBatch);

--- a/src/data-loader/SubmissionScoreLoader.ts
+++ b/src/data-loader/SubmissionScoreLoader.ts
@@ -1,0 +1,21 @@
+import * as DataLoader from "dataloader";
+import { ISubmissionRepo } from "../interfaces/ISubmissionRepo";
+import { container } from "../inversify.config";
+import { TYPES } from "../types/types";
+
+const scoreBatch = async (keys: number[]): Promise<number[]> => {
+    const submissionRepo = container.get<ISubmissionRepo>(
+        TYPES.ISubmissionRepo
+    );
+    const datas = await submissionRepo.getScores(keys);
+
+    const scoreMap: { [key: number]: number } = {};
+    datas.forEach((data) => {
+        scoreMap[data.id] = data.score;
+    });
+
+    return keys.map((key) => scoreMap[key]);
+};
+
+export const SubmissionScoreLoader = () =>
+    new DataLoader<number, number>(scoreBatch);

--- a/src/data-loader/UserLoader.ts
+++ b/src/data-loader/UserLoader.ts
@@ -1,0 +1,21 @@
+import * as DataLoader from "dataloader";
+import { User } from "../entity/User";
+import { IUserRepo } from "../interfaces/IUserRepo";
+import { container } from "../inversify.config";
+import { TYPES } from "../types/types";
+
+const userBatch = async (keys: number[]): Promise<User[]> => {
+    const userRepo = container.get<IUserRepo>(TYPES.IUserRepo);
+    const users = await userRepo.findByIds(keys);
+
+    const userMap: {
+        [key: number]: User;
+    } = {};
+    users.forEach((u) => {
+        userMap[u.id] = u;
+    });
+
+    return keys.map((key) => userMap[key]);
+};
+
+export const UserLoader = () => new DataLoader<number, User>(userBatch);

--- a/src/entity/Difficulty.ts
+++ b/src/entity/Difficulty.ts
@@ -19,7 +19,7 @@ export class Difficulty extends BaseEntity {
     @Field()
     type: string;
 
-    @Field(() => [Quiz])
+    // @Field(() => [Quiz])
     @OneToMany(() => Quiz, (quiz: Quiz) => quiz.difficulty)
     quizzes: Quiz[];
 }

--- a/src/entity/Question.ts
+++ b/src/entity/Question.ts
@@ -22,7 +22,6 @@ export class Question extends BaseEntity {
     @Column()
     question: string;
 
-    @Field(() => [Answer])
     @OneToMany(() => Answer, (answer: Answer) => answer.question)
     answers: Answer[];
 

--- a/src/entity/Quiz.ts
+++ b/src/entity/Quiz.ts
@@ -28,19 +28,17 @@ export class Quiz extends BaseEntity {
     @Column()
     authorId: number;
 
-    @Field(() => User)
     @ManyToOne(() => User, (user: User) => user.quizzes)
     @JoinColumn({ name: "authorId" })
     author: User;
 
     @Column()
     difficultyId: number;
-    @Field(() => Difficulty)
+
     @ManyToOne(() => Difficulty, (difficulty: Difficulty) => difficulty.quizzes)
     @JoinColumn({ name: "difficultyId" })
     difficulty: Difficulty;
 
-    @Field(() => [Question])
     @OneToMany(() => Question, (question) => question.quiz)
     questions: Question[];
 
@@ -49,8 +47,8 @@ export class Quiz extends BaseEntity {
 
     @Column()
     categoryId: number;
+
     @ManyToOne(() => Category, (category: Category) => category.quizzes)
     @JoinColumn({ name: "categoryId" })
-    @Field(() => Category)
     category: Category;
 }

--- a/src/entity/Submission.ts
+++ b/src/entity/Submission.ts
@@ -1,4 +1,4 @@
-import { Field, ID, Int, ObjectType } from "type-graphql";
+import { Field, ID, ObjectType } from "type-graphql";
 import {
     BaseEntity,
     Column,
@@ -30,12 +30,10 @@ export class Submission extends BaseEntity {
     @Column()
     quizId: number;
 
-    @Field(() => Quiz)
     @ManyToOne(() => Quiz, (quiz: Quiz) => quiz.submissions)
     @JoinColumn({ name: "quizId" })
     quiz: Quiz;
 
-    @Field(() => [Answer])
     @ManyToMany(() => Answer, (answer) => answer.submissions)
     @JoinTable({ name: "submission_answer" })
     answers: Answer[];

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -31,7 +31,7 @@ export class User extends BaseEntity {
     @OneToMany(() => Submission, (submission: Submission) => submission.user)
     submissions: Submission[];
 
-    @Field(() => [Quiz])
+    // @Field(() => [Quiz])
     @OneToMany(() => Quiz, (quiz: Quiz) => quiz.author)
     quizzes: Quiz[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { QuizQuestionsLoader } from "./data-loader/QuizQuestionsLoader";
 import { SubmissionAnswersLoader } from "./data-loader/SubmissionAnswersLoader";
 import { QuizLoader } from "./data-loader/QuizLoader";
 import { QuestionAnswersLoader } from "./data-loader/QuestionAnswersLoader";
+import { SubmissionScoreLoader } from "./data-loader/SubmissionScoreLoader";
 
 createConnection()
     .then(async () => {
@@ -40,6 +41,7 @@ createConnection()
                     quizQuestionsLoader: QuizQuestionsLoader(),
                     submissionAnswersLoader: SubmissionAnswersLoader(),
                     questionAnswersLoader: QuestionAnswersLoader(),
+                    submissionScoreLoader: SubmissionScoreLoader(),
                 } as TContext),
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,11 @@ import { IDifficultyRepo } from "./interfaces/IDifficultyRepo";
 import { TYPES } from "./types/types";
 
 import { ApolloServer } from "apollo-server";
+import { UserLoader } from "./data-loader/UserLoader";
+import { TContext } from "./types/TContext";
+import { DifficultyLoader } from "./data-loader/DifficultyLoader";
+import { CategoryLoader } from "./data-loader/CategoryLoader";
+import { QuestionsLoader } from "./data-loader/QuestionsLoader";
 
 createConnection()
     .then(async () => {
@@ -22,7 +27,14 @@ createConnection()
         const server = new ApolloServer({
             schema,
             playground: true,
-            context: ({ req }) => req,
+            context: ({ req }) =>
+                ({
+                    ...req,
+                    userLoader: UserLoader(),
+                    difficultyLoader: DifficultyLoader(),
+                    categoryLoader: CategoryLoader(),
+                    questionsLoader: QuestionsLoader(),
+                } as TContext),
         });
 
         const { url } = await server.listen(5000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { CategoryLoader } from "./data-loader/CategoryLoader";
 import { QuizQuestionsLoader } from "./data-loader/QuizQuestionsLoader";
 import { SubmissionAnswersLoader } from "./data-loader/SubmissionAnswersLoader";
 import { QuizLoader } from "./data-loader/QuizLoader";
+import { QuestionAnswersLoader } from "./data-loader/QuestionAnswersLoader";
 
 createConnection()
     .then(async () => {
@@ -38,6 +39,7 @@ createConnection()
                     categoryLoader: CategoryLoader(),
                     quizQuestionsLoader: QuizQuestionsLoader(),
                     submissionAnswersLoader: SubmissionAnswersLoader(),
+                    questionAnswersLoader: QuestionAnswersLoader(),
                 } as TContext),
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,9 @@ import { UserLoader } from "./data-loader/UserLoader";
 import { TContext } from "./types/TContext";
 import { DifficultyLoader } from "./data-loader/DifficultyLoader";
 import { CategoryLoader } from "./data-loader/CategoryLoader";
-import { QuestionsLoader } from "./data-loader/QuestionsLoader";
+import { QuizQuestionsLoader } from "./data-loader/QuizQuestionsLoader";
+import { SubmissionAnswersLoader } from "./data-loader/SubmissionAnswersLoader";
+import { QuizLoader } from "./data-loader/QuizLoader";
 
 createConnection()
     .then(async () => {
@@ -31,9 +33,11 @@ createConnection()
                 ({
                     ...req,
                     userLoader: UserLoader(),
+                    quizLoader: QuizLoader(),
                     difficultyLoader: DifficultyLoader(),
                     categoryLoader: CategoryLoader(),
-                    questionsLoader: QuestionsLoader(),
+                    quizQuestionsLoader: QuizQuestionsLoader(),
+                    submissionAnswersLoader: SubmissionAnswersLoader(),
                 } as TContext),
         });
 

--- a/src/interfaces/ICategoryRepo.ts
+++ b/src/interfaces/ICategoryRepo.ts
@@ -7,4 +7,13 @@ export interface ICategoryRepo {
 
     // Get all quizzes with given category
     getQuizzes(categoryName: string): Promise<Quiz[]>;
+
+    // Find Category object with given id
+    findById(id: number): Promise<Category>;
+
+    // Find Category objects with given id list
+    findByIds(ids: number[]): Promise<Category[]>;
+
+    // Find Category object with given category name
+    findByCategoryName(categoryName: string): Promise<Category>;
 }

--- a/src/interfaces/IDifficultyRepo.ts
+++ b/src/interfaces/IDifficultyRepo.ts
@@ -12,4 +12,12 @@ export interface IDifficultyRepo {
     // Find Difficulty object by given name
     // type - name of difficulty (Easy | Normal | Hard)
     getObjByType: (type: string) => Promise<Difficulty>;
+
+    // Find Difficulty object by id
+    // id: id of target object
+    findById: (id: number) => Promise<Difficulty>;
+
+    // Find Difficulty objects based on list of ids
+    // ids: list of ids
+    findByIds: (ids: number[]) => Promise<Difficulty[]>;
 }

--- a/src/interfaces/IQuestionRepo.ts
+++ b/src/interfaces/IQuestionRepo.ts
@@ -8,4 +8,7 @@ export interface IQuestionRepo {
 
     // Get all questions in the databasse (regardless of quiz)
     findAll: () => Promise<Question[]>;
+
+    // Get all questions of a quiz
+    findByQuizId: (id: number) => Promise<Question[]>;
 }

--- a/src/interfaces/IQuestionRepo.ts
+++ b/src/interfaces/IQuestionRepo.ts
@@ -11,4 +11,7 @@ export interface IQuestionRepo {
 
     // Get all questions of a quiz
     findByQuizId: (id: number) => Promise<Question[]>;
+
+    // Get questions with answers eagerly loaded based on given id list
+    findByIdsWithAnswers: (ids: number[]) => Promise<Question[]>;
 }

--- a/src/interfaces/IQuizRepo.ts
+++ b/src/interfaces/IQuizRepo.ts
@@ -40,6 +40,10 @@ export interface IQuizRepo {
     // Find a list of quizzes with given list of ID
     findByIds: (ids: number[]) => Promise<Quiz[]>;
 
+    // Find a list of quizzes with eager loading of questions
+    // with given list of ID
+    findByIdsWithQuestions: (ids: number[]) => Promise<Quiz[]>;
+
     // Find all quizzes that is written by given User
     findByAuthor: (authorId: number) => Promise<Quiz[]>;
 

--- a/src/interfaces/IQuizRepo.ts
+++ b/src/interfaces/IQuizRepo.ts
@@ -43,6 +43,12 @@ export interface IQuizRepo {
     // Find a quiz with a given name
     findByName: (name: string) => Promise<Quiz>;
 
+    // Find all quizzes by difficulty
+    findByDifficulty: (difficultyId: number) => Promise<Quiz[]>;
+
+    // Find all quizzes by category
+    findByCategory: (categoryId: number) => Promise<Quiz[]>;
+
     // Find quizzes (pagination)
     // offset: number of submissions to skip
     // limit: number of submissions to get

--- a/src/interfaces/IQuizRepo.ts
+++ b/src/interfaces/IQuizRepo.ts
@@ -37,6 +37,9 @@ export interface IQuizRepo {
     // Find a quiz with given ID
     findById: (id: number) => Promise<Quiz>;
 
+    // Find a list of quizzes with given list of ID
+    findByIds: (ids: number[]) => Promise<Quiz[]>;
+
     // Find all quizzes that is written by given User
     findByAuthor: (authorId: number) => Promise<Quiz[]>;
 

--- a/src/interfaces/ISubmissionRepo.ts
+++ b/src/interfaces/ISubmissionRepo.ts
@@ -17,6 +17,10 @@ export interface ISubmissionRepo {
     // Find a submission with a given id
     findById: (id: number) => Promise<Submission>;
 
+    // Find list of submissions with a given id list
+    // (With answers eagerly loaded)
+    findByIdsWithAnswers: (ids: number[]) => Promise<Submission[]>;
+
     // Get score of the submission with given id
     getScore: (submissionId: number) => Promise<number>;
 

--- a/src/interfaces/ISubmissionRepo.ts
+++ b/src/interfaces/ISubmissionRepo.ts
@@ -20,6 +20,11 @@ export interface ISubmissionRepo {
     // Get score of the submission with given id
     getScore: (submissionId: number) => Promise<number>;
 
+    // Get score of the submission with given id
+    getScores: (
+        submissionIds: number[]
+    ) => Promise<Array<{ id: number; score: number }>>;
+
     // Get all submissions of a user (pagination)
     // offset: number of submissions to skip
     // limit: number of submissions to get

--- a/src/interfaces/IUserRepo.ts
+++ b/src/interfaces/IUserRepo.ts
@@ -42,4 +42,8 @@ export interface IUserRepo {
     // Get total and max score among all submissions of a user
     // id: id of target user
     getScore: (id: number) => Promise<UserScore[]>;
+
+    // Get user by list of id
+    // ids: array of ids
+    findByIds: (ids: number[]) => Promise<User[]>;
 }

--- a/src/interfaces/IUserRepo.ts
+++ b/src/interfaces/IUserRepo.ts
@@ -3,9 +3,6 @@ import { User } from "../entity/User";
 
 @ObjectType()
 export class AuthResponse {
-    @Field(() => Int)
-    statusCode: number;
-
     @Field()
     token: string;
 

--- a/src/repositories/CategoryRepo.ts
+++ b/src/repositories/CategoryRepo.ts
@@ -2,6 +2,9 @@ import { injectable } from "inversify";
 import { Category } from "../entity/Category";
 import { Quiz } from "../entity/Quiz";
 import { ICategoryRepo } from "../interfaces/ICategoryRepo";
+import { IQuizRepo } from "../interfaces/IQuizRepo";
+import { container } from "../inversify.config";
+import { TYPES } from "../types/types";
 
 @injectable()
 export class CategoryRepo implements ICategoryRepo {
@@ -14,18 +17,11 @@ export class CategoryRepo implements ICategoryRepo {
     }
 
     async getQuizzes(categoryName: string): Promise<Quiz[]> {
-        const catObj = await Category.findOne({
-            relations: [
-                "quizzes",
-                "quizzes.questions",
-                "quizzes.questions.answers",
-                "quizzes.difficulty",
-                "quizzes.category",
-            ],
-            where: { categoryName },
-        });
-        if (!catObj) return [];
-        return catObj.quizzes;
+        const catObj = await this.findByCategoryName(categoryName);
+        const quizzes = await container
+            .get<IQuizRepo>(TYPES.IQuizRepo)
+            .findByCategory(catObj.id);
+        return quizzes;
     }
 
     async findById(id: number): Promise<Category> {

--- a/src/repositories/CategoryRepo.ts
+++ b/src/repositories/CategoryRepo.ts
@@ -27,4 +27,20 @@ export class CategoryRepo implements ICategoryRepo {
         if (!catObj) return [];
         return catObj.quizzes;
     }
+
+    async findById(id: number): Promise<Category> {
+        return Category.findOne(id);
+    }
+
+    async findByIds(ids: number[]): Promise<Category[]> {
+        return Category.findByIds(ids);
+    }
+
+    async findByCategoryName(categoryName: string): Promise<Category> {
+        return Category.findOne({
+            where: {
+                categoryName,
+            },
+        });
+    }
 }

--- a/src/repositories/DifficultyRepo.ts
+++ b/src/repositories/DifficultyRepo.ts
@@ -33,9 +33,19 @@ export class DifficultyRepo implements IDifficultyRepo {
         return diffObj.quizzes;
     }
 
-    async getObjByType(type: string): Promise<Difficulty> {
+    getObjByType(type: string): Promise<Difficulty> {
         return Difficulty.findOne({
             type,
         });
+    }
+
+    findById(id: number): Promise<Difficulty> {
+        return Difficulty.findOne({
+            id,
+        });
+    }
+
+    findByIds(ids: number[]): Promise<Difficulty[]> {
+        return Difficulty.findByIds(ids);
     }
 }

--- a/src/repositories/DifficultyRepo.ts
+++ b/src/repositories/DifficultyRepo.ts
@@ -2,6 +2,9 @@ import { injectable } from "inversify";
 import { Difficulty } from "../entity/Difficulty";
 import { Quiz } from "../entity/Quiz";
 import { IDifficultyRepo } from "../interfaces/IDifficultyRepo";
+import { IQuizRepo } from "../interfaces/IQuizRepo";
+import { container } from "../inversify.config";
+import { TYPES } from "../types/types";
 
 @injectable()
 export class DifficultyRepo implements IDifficultyRepo {
@@ -18,19 +21,11 @@ export class DifficultyRepo implements IDifficultyRepo {
     }
 
     async getQuizzes(type: string): Promise<Quiz[]> {
-        const diffObj = await Difficulty.findOne({
-            relations: [
-                "quizzes",
-                "quizzes.questions",
-                "quizzes.questions.answers",
-                "quizzes.category",
-            ],
-            where: {
-                type,
-            },
-        });
-        if (!diffObj) return [];
-        return diffObj.quizzes;
+        const diffObj = await this.getObjByType(type);
+        const quizzes = await container
+            .get<IQuizRepo>(TYPES.IQuizRepo)
+            .findByDifficulty(diffObj.id);
+        return quizzes;
     }
 
     getObjByType(type: string): Promise<Difficulty> {

--- a/src/repositories/QuestionRepo.ts
+++ b/src/repositories/QuestionRepo.ts
@@ -8,9 +8,7 @@ export class QuestionRepo implements IQuestionRepo {
         return Question.create({ question, quizId }).save();
     }
     findAll(): Promise<Question[]> {
-        return Question.find({
-            relations: ["answers"],
-        });
+        return Question.find();
     }
     findByQuizId(quizId: number): Promise<Question[]> {
         return Question.find({

--- a/src/repositories/QuestionRepo.ts
+++ b/src/repositories/QuestionRepo.ts
@@ -7,9 +7,14 @@ export class QuestionRepo implements IQuestionRepo {
     initializeObj(question: string, quizId: number): Promise<Question> {
         return Question.create({ question, quizId }).save();
     }
-    findAll() : Promise<Question[]> {
+    findAll(): Promise<Question[]> {
         return Question.find({
             relations: ["answers"],
+        });
+    }
+    findByQuizId(quizId: number): Promise<Question[]> {
+        return Question.find({
+            quizId,
         });
     }
 }

--- a/src/repositories/QuestionRepo.ts
+++ b/src/repositories/QuestionRepo.ts
@@ -15,4 +15,10 @@ export class QuestionRepo implements IQuestionRepo {
             quizId,
         });
     }
+    findByIdsWithAnswers(ids: number[]): Promise<Question[]> {
+        return Question.createQueryBuilder("question")
+            .leftJoinAndSelect("question.answers", "answer")
+            .where("question.id in (:...ids)", { ids })
+            .getMany();
+    }
 }

--- a/src/repositories/QuizRepo.ts
+++ b/src/repositories/QuizRepo.ts
@@ -82,6 +82,10 @@ export class QuizRepo implements IQuizRepo {
         return Quiz.findOne({ id });
     }
 
+    findByIds(ids: number[]): Promise<Quiz[]> {
+        return Quiz.findByIds(ids);
+    }
+
     async findByAuthor(authorId: number): Promise<Quiz[]> {
         return Quiz.find({
             where: { authorId },

--- a/src/repositories/QuizRepo.ts
+++ b/src/repositories/QuizRepo.ts
@@ -86,6 +86,13 @@ export class QuizRepo implements IQuizRepo {
         return Quiz.findByIds(ids);
     }
 
+    findByIdsWithQuestions(ids: number[]): Promise<Quiz[]> {
+        return Quiz.createQueryBuilder("quiz")
+            .leftJoinAndSelect("quiz.questions", "question")
+            .where("quiz.id in (:...ids)", { ids })
+            .getMany();
+    }
+
     async findByAuthor(authorId: number): Promise<Quiz[]> {
         return Quiz.find({
             where: { authorId },

--- a/src/repositories/QuizRepo.ts
+++ b/src/repositories/QuizRepo.ts
@@ -75,36 +75,15 @@ export class QuizRepo implements IQuizRepo {
         return newQuiz;
     }
     async findAll(): Promise<Quiz[]> {
-        return Quiz.find({
-            relations: ["difficulty", "category", "author"],
-        });
+        return Quiz.find();
     }
 
     async findById(id: number): Promise<Quiz> {
-        return Quiz.findOne(
-            { id },
-            {
-                relations: [
-                    "difficulty",
-                    "questions",
-                    "questions.answers",
-                    "submissions",
-                    "category",
-                    "author",
-                ],
-            }
-        );
+        return Quiz.findOne({ id });
     }
 
     async findByAuthor(authorId: number): Promise<Quiz[]> {
         return Quiz.find({
-            relations: [
-                "difficulty",
-                "questions",
-                "questions.answers",
-                "submissions",
-                "category",
-            ],
             where: { authorId },
         });
     }
@@ -112,10 +91,23 @@ export class QuizRepo implements IQuizRepo {
     async findByName(name: string): Promise<Quiz> {
         return Quiz.createQueryBuilder("quiz")
             .where("LOWER(quiz.quizName) = LOWER(:name)", { name })
-            .innerJoinAndSelect("quiz.difficulty", "difficulty")
-            .innerJoinAndSelect("quiz.category", "category")
-            .innerJoinAndSelect("quiz.author", "user")
             .getOne();
+    }
+
+    findByDifficulty(difficultyId: number): Promise<Quiz[]> {
+        return Quiz.find({
+            where: {
+                difficultyId,
+            },
+        });
+    }
+
+    findByCategory(categoryId: number): Promise<Quiz[]> {
+        return Quiz.find({
+            where: {
+                categoryId,
+            },
+        });
     }
 
     async findWithOffsetAndLimit(
@@ -123,9 +115,6 @@ export class QuizRepo implements IQuizRepo {
         limit: number
     ): Promise<Quiz[]> {
         return Quiz.createQueryBuilder("quiz")
-            .innerJoinAndSelect("quiz.difficulty", "difficulty")
-            .innerJoinAndSelect("quiz.category", "category")
-            .innerJoinAndSelect("quiz.author", "user")
             .skip(offset)
             .take(limit)
             .getMany();

--- a/src/repositories/SubmissionRepo.ts
+++ b/src/repositories/SubmissionRepo.ts
@@ -1,6 +1,5 @@
 import { injectable } from "inversify";
 import { getManager } from "typeorm";
-import { Answer } from "../entity/Answer";
 import { Submission } from "../entity/Submission";
 import { CountData } from "../interfaces/ICountData";
 import { ISubmissionRepo, SubmissionArg } from "../interfaces/ISubmissionRepo";

--- a/src/repositories/SubmissionRepo.ts
+++ b/src/repositories/SubmissionRepo.ts
@@ -34,14 +34,7 @@ export class SubmissionRepo implements ISubmissionRepo {
         );
     }
     findById(id: number): Promise<Submission> {
-        return Submission.findOne(
-            {
-                id,
-            },
-            {
-                relations: ["answers", "answers.submissions"],
-            }
-        );
+        return Submission.findOne(id);
     }
     async getScore(submissionId: number): Promise<number> {
         const subObj = await Submission.findOne(
@@ -60,7 +53,6 @@ export class SubmissionRepo implements ISubmissionRepo {
     getUserSubmissions(userId: number): Promise<Submission[]> {
         return Submission.find({
             where: { userId },
-            relations: ["answers", "quiz", "quiz.difficulty"],
         });
     }
     getUserSubmissionsWithOffsetAndLimit(
@@ -69,9 +61,6 @@ export class SubmissionRepo implements ISubmissionRepo {
         limit: number
     ): Promise<Submission[]> {
         return Submission.createQueryBuilder("submission")
-            .innerJoinAndSelect("submission.answers", "answer")
-            .innerJoinAndSelect("submission.quiz", "quiz")
-            .innerJoinAndSelect("quiz.difficulty", "difficulty")
             .skip(offset)
             .take(limit)
             .where("submission.userId = :userId", { userId })

--- a/src/repositories/SubmissionRepo.ts
+++ b/src/repositories/SubmissionRepo.ts
@@ -23,9 +23,18 @@ export class SubmissionRepo implements ISubmissionRepo {
         });
         return newSubmission;
     }
+
     findById(id: number): Promise<Submission> {
         return Submission.findOne(id);
     }
+
+    findByIdsWithAnswers(ids: number[]): Promise<Submission[]> {
+        return Submission.createQueryBuilder("submission")
+            .leftJoinAndSelect("submission.answers", "answer")
+            .where("submission.id in (:...ids)", { ids })
+            .getMany();
+    }
+
     async getScore(submissionId: number): Promise<number> {
         const queryData = await getManager().query(`
             select count(case when answer.isCorrect = 1 then 1 end) * 100 / count(*) as score, submission.userId from submission 

--- a/src/repositories/SubmissionRepo.ts
+++ b/src/repositories/SubmissionRepo.ts
@@ -17,13 +17,10 @@ export class SubmissionRepo implements ISubmissionRepo {
             quizId,
         }).save();
         answers.forEach(async (answerId) => {
-            const fetchedAnswer = await Answer.findOne({
-                id: answerId,
-            });
-            await Submission.createQueryBuilder()
-                .relation(Submission, "answers")
-                .of(newSubmission)
-                .add(fetchedAnswer);
+            await getManager().query(`
+                insert into \`submission_answer\`(\`id\`, \`submissionId\`, \`answerId\`) 
+                values(default, ${newSubmission.id}, ${answerId})
+            `);
         });
         return newSubmission;
     }

--- a/src/repositories/SubmissionRepo.ts
+++ b/src/repositories/SubmissionRepo.ts
@@ -39,6 +39,23 @@ export class SubmissionRepo implements ISubmissionRepo {
         `);
         return parseInt(queryData[0].score);
     }
+
+    async getScores(
+        submissionIds: number[]
+    ): Promise<Array<{ id: number; score: number }>> {
+        const queryData = await getManager().query(`
+            select count(case when answer.isCorrect = 1 then 1 end) * 100 / count(*) as score, submission.id from submission 
+            inner join submission_answer on submission.id = submission_answer.submissionId
+            inner join answer on submission_answer.answerId = answer.id
+            where submission.id in (${submissionIds.join(", ")})
+            group by submission.id
+        `);
+        return queryData.map((obj: { id: string; score: string }) => ({
+            id: parseInt(obj.id),
+            score: parseInt(obj.score),
+        }));
+    }
+
     getUserSubmissions(userId: number): Promise<Submission[]> {
         return Submission.find({
             where: { userId },

--- a/src/repositories/UserRepo.ts
+++ b/src/repositories/UserRepo.ts
@@ -37,4 +37,8 @@ export class UserRepo implements IUserRepo {
             ) as T2;
         `);
     }
+
+    findByIds(ids: number[]): Promise<User[]> {
+        return User.findByIds(ids);
+    }
 }

--- a/src/resolvers/QuestionResolver.ts
+++ b/src/resolvers/QuestionResolver.ts
@@ -1,22 +1,21 @@
-import { injectable } from "inversify";
-import { Query, Resolver } from "type-graphql";
+import { Ctx, FieldResolver, Resolver, Root } from "type-graphql";
 import { Question } from "../entity/Question";
 
-import getDecorators from "inversify-inject-decorators";
-import { container } from "../inversify.config";
-import { TYPES } from "../types/types";
-import { IQuestionRepo } from "../interfaces/IQuestionRepo";
-const { lazyInject } = getDecorators(container);
+import { Answer } from "../entity/Answer";
+import { TContext } from "../types/TContext";
 
-@injectable()
-@Resolver()
+@Resolver(Question)
 export class QuestionResolver {
-    @lazyInject(TYPES.IQuestionRepo) private _questionRepo: IQuestionRepo;
-    @Query(() => [Question])
-    async questions(): Promise<Question[]> {
+    @FieldResolver(() => [Answer])
+    async answers(
+        @Ctx() context: TContext,
+        @Root() question: Question
+    ): Promise<Answer[]> {
         try {
-            const questions = await this._questionRepo.findAll();
-            return questions;
+            const answers = await context.questionAnswersLoader.load(
+                question.id
+            );
+            return answers;
         } catch (error) {
             console.log(error);
             throw new Error("Database Error");

--- a/src/resolvers/SubmissionResolver.ts
+++ b/src/resolvers/SubmissionResolver.ts
@@ -1,6 +1,7 @@
 import { injectable } from "inversify";
 import {
     Arg,
+    Ctx,
     Field,
     FieldResolver,
     ID,
@@ -18,6 +19,9 @@ import getDecorators from "inversify-inject-decorators";
 import { TYPES } from "../types/types";
 import { ISubmissionRepo, SubmissionArg } from "../interfaces/ISubmissionRepo";
 import { ResourceNotFound } from "../errors/ResourceNotFound";
+import { Answer } from "../entity/Answer";
+import { TContext } from "../types/TContext";
+import { Quiz } from "../entity/Quiz";
 const { lazyInject } = getDecorators(container);
 
 @InputType()
@@ -72,6 +76,34 @@ export class SubmissionResolver {
     async score(@Root() submission: Submission): Promise<number> {
         try {
             return this._submissionRepo.getScore(submission.id);
+        } catch (error) {
+            console.log(error);
+            throw new Error("Database Error");
+        }
+    }
+
+    @FieldResolver(() => [Answer])
+    async answers(
+        @Ctx() context: TContext,
+        @Root() submission: Submission
+    ): Promise<Answer[]> {
+        try {
+            const anss = context.submissionAnswersLoader.load(submission.id);
+            return anss;
+        } catch (error) {
+            console.log(error);
+            throw new Error("Database Error");
+        }
+    }
+
+    @FieldResolver(() => Quiz)
+    async quiz(
+        @Ctx() context: TContext,
+        @Root() submission: Submission
+    ): Promise<Quiz> {
+        try {
+            const quizObj = await context.quizLoader.load(submission.quizId);
+            return quizObj;
         } catch (error) {
             console.log(error);
             throw new Error("Database Error");

--- a/src/resolvers/SubmissionResolver.ts
+++ b/src/resolvers/SubmissionResolver.ts
@@ -58,18 +58,15 @@ export class SubmissionResolver {
 
     @Query(() => Submission)
     async submissionById(@Arg("id") id: number): Promise<Submission> {
-        try {
-            const submission = await this._submissionRepo.findById(id);
-            if (!submission)
-                throw new ResourceNotFound("Submission does not exist");
-            return submission;
-        } catch (error) {
-            if (error instanceof ResourceNotFound) throw error;
-            else {
+        const submission = await this._submissionRepo
+            .findById(id)
+            .catch((error) => {
                 console.log(error);
                 throw new Error("Database Error");
-            }
-        }
+            });
+        if (!submission)
+            throw new ResourceNotFound("Submission does not exist");
+        return submission;
     }
 
     @FieldResolver(() => Int)

--- a/src/resolvers/SubmissionResolver.ts
+++ b/src/resolvers/SubmissionResolver.ts
@@ -73,9 +73,15 @@ export class SubmissionResolver {
     }
 
     @FieldResolver(() => Int)
-    async score(@Root() submission: Submission): Promise<number> {
+    async score(
+        @Ctx() context: TContext,
+        @Root() submission: Submission
+    ): Promise<number> {
         try {
-            return this._submissionRepo.getScore(submission.id);
+            const score = await context.submissionScoreLoader.load(
+                submission.id
+            );
+            return score;
         } catch (error) {
             console.log(error);
             throw new Error("Database Error");

--- a/src/resolvers/UserResolver.ts
+++ b/src/resolvers/UserResolver.ts
@@ -226,7 +226,10 @@ export class UserResolver {
     async myScore(@Ctx() context: TContext): Promise<UserScore> {
         try {
             const data = await this._userRepo.getScore(context.user.id);
-            return data[0];
+            return {
+                maxScore: data[0].maxScore || 0,
+                totalScore: data[0].totalScore || 0,
+            };
         } catch (error) {
             console.log(error);
             throw new Error("Database Error");

--- a/src/resolvers/UserResolver.ts
+++ b/src/resolvers/UserResolver.ts
@@ -54,14 +54,12 @@ export class UserResolver {
         @Arg("email") email: string,
         @Arg("password") password: string
     ): Promise<AuthResponse> {
-        let existingUser: User;
-
-        try {
-            existingUser = await this._userRepo.findByEmail(email);
-        } catch (error) {
-            console.log(error);
-            throw new Error("Database Error");
-        }
+        const existingUser = await this._userRepo
+            .findByEmail(email)
+            .catch((error) => {
+                console.log(error);
+                throw new Error("Database Error");
+            });
 
         if (!existingUser) throw new AuthenticationError("User does not exist");
         const checkValid = await bcrypt.compare(
@@ -85,13 +83,12 @@ export class UserResolver {
     @Query(() => User)
     @UseMiddleware(checkAuthorization)
     async myInfo(@Ctx() context: TContext): Promise<User> {
-        let user: User;
-        try {
-            user = await this._userRepo.findById(context.user.id);
-        } catch (error) {
-            console.log(error);
-            throw new Error("Database Error");
-        }
+        const user = await this._userRepo
+            .findById(context.user.id)
+            .catch((error) => {
+                console.log(error);
+                throw new Error("Database Error");
+            });
         if (!user) throw new AuthenticationError("User Not Found");
         return user;
     }
@@ -99,15 +96,13 @@ export class UserResolver {
     @Query(() => [Submission])
     @UseMiddleware(checkAuthorization)
     async mySubmissions(@Ctx() context: TContext): Promise<Submission[]> {
-        try {
-            const submissions = await this._submissionRepo.getUserSubmissions(
-                context.user.id
-            );
-            return submissions;
-        } catch (error) {
-            console.log(error);
-            throw new Error("Database Error");
-        }
+        const submissions = await this._submissionRepo
+            .getUserSubmissions(context.user.id)
+            .catch((error) => {
+                console.log(error);
+                throw new Error("Database Error");
+            });
+        return submissions;
     }
 
     @Query(() => [Submission])
@@ -116,17 +111,13 @@ export class UserResolver {
         @Ctx() context: TContext,
         @Arg("limit") limit: number
     ): Promise<Submission[]> {
-        try {
-            const submissions =
-                await this._submissionRepo.getUserRecentSubmissions(
-                    context.user.id,
-                    limit
-                );
-            return submissions;
-        } catch (error) {
-            console.log(error);
-            throw new Error("Database Error");
-        }
+        const submissions = await this._submissionRepo
+            .getUserRecentSubmissions(context.user.id, limit)
+            .catch((error) => {
+                console.log(error);
+                throw new Error("Database Error");
+            });
+        return submissions;
     }
 
     @Mutation(() => AuthResponse)
@@ -136,14 +127,12 @@ export class UserResolver {
         @Arg("email") email: string,
         @Arg("password") password: string
     ): Promise<AuthResponse> {
-        let existingUser: User;
-
-        try {
-            existingUser = await this._userRepo.findByEmail(email);
-        } catch (error) {
-            console.log(error);
-            throw new Error("Database error");
-        }
+        const existingUser = await this._userRepo
+            .findByEmail(email)
+            .catch((error) => {
+                console.log(error);
+                throw new Error("Database error");
+            });
 
         if (existingUser)
             throw new UserInputError("Create user failed", {
@@ -152,27 +141,19 @@ export class UserResolver {
                 },
             });
 
-        let hashedPassword: string;
+        const hashedPassword = await bcrypt
+            .hash(password, 10)
+            .catch((error) => {
+                console.log(error);
+                throw new Error("Database Error");
+            });
 
-        try {
-            hashedPassword = await bcrypt.hash(password, 10);
-        } catch (error) {
-            console.log(error);
-            throw new Error("Database Error");
-        }
-
-        let newUser: User;
-
-        try {
-            newUser = await this._userRepo.initializeObj(
-                name,
-                email,
-                hashedPassword
-            );
-        } catch (error) {
-            console.log(error);
-            throw new Error("Database Error");
-        }
+        const newUser = await this._userRepo
+            .initializeObj(name, email, hashedPassword)
+            .catch((error) => {
+                console.log(error);
+                throw new Error("Database Error");
+            });
 
         return {
             statusCode: 200,
@@ -188,13 +169,13 @@ export class UserResolver {
     @Query(() => [Quiz])
     @UseMiddleware(checkAuthorization)
     async myQuizzes(@Ctx() context: TContext): Promise<Quiz[]> {
-        try {
-            const quizzes = this._quizRepo.findByAuthor(context.user.id);
-            return quizzes;
-        } catch (error) {
-            console.log(error);
-            throw new Error("Database Error");
-        }
+        const quizzes = this._quizRepo
+            .findByAuthor(context.user.id)
+            .catch((error) => {
+                console.log(error);
+                throw new Error("Database Error");
+            });
+        return quizzes;
     }
 
     @Mutation(() => User)
@@ -239,26 +220,24 @@ export class UserResolver {
     @Query(() => CountData)
     @UseMiddleware(checkAuthorization)
     async countMySubmissions(@Ctx() context: TContext): Promise<CountData> {
-        try {
-            const data = await this._submissionRepo.getUserSubmissionsCount(
-                context.user.id
-            );
-            return data;
-        } catch (error) {
-            console.log(error);
-            throw new Error("Database Error");
-        }
+        const data = await this._submissionRepo
+            .getUserSubmissionsCount(context.user.id)
+            .catch((error) => {
+                console.log(error);
+                throw new Error("Database Error");
+            });
+        return data;
     }
 
     @Query(() => CountData)
     @UseMiddleware(checkAuthorization)
     async countMyQuizzes(@Ctx() context: TContext): Promise<CountData> {
-        try {
-            const data = await this._quizRepo.getUserQuizCount(context.user.id);
-            return data;
-        } catch (error) {
-            console.log(error);
-            throw new Error("Database Error");
-        }
+        const data = await this._quizRepo
+            .getUserQuizCount(context.user.id)
+            .catch((error) => {
+                console.log(error);
+                throw new Error("Database Error");
+            });
+        return data;
     }
 }

--- a/src/resolvers/UserResolver.ts
+++ b/src/resolvers/UserResolver.ts
@@ -70,7 +70,6 @@ export class UserResolver {
         if (!checkValid) throw new AuthenticationError("Invalid credentials");
 
         return {
-            statusCode: 200,
             token: generateToken({
                 id: existingUser.id,
             }),
@@ -156,7 +155,6 @@ export class UserResolver {
             });
 
         return {
-            statusCode: 200,
             token: generateToken({
                 id: newUser.id,
             }),

--- a/src/resolvers/quiz/QuizResolver.ts
+++ b/src/resolvers/quiz/QuizResolver.ts
@@ -60,8 +60,7 @@ export class QuizResolver {
         @Arg("difficulty") difficulty: string
     ): Promise<Quiz[]> {
         try {
-            const diffObj = await this._difficultyRepo.getObjByType(difficulty);
-            const quizzes = await this._quizRepo.findByDifficulty(diffObj.id);
+            const quizzes = await this._difficultyRepo.getQuizzes(difficulty);
             return quizzes;
         } catch (error) {
             console.log(error);
@@ -74,10 +73,7 @@ export class QuizResolver {
         @Arg("category") category: string
     ): Promise<Quiz[]> {
         try {
-            const catObj = await this._categoryRepo.findByCategoryName(
-                category
-            );
-            const quizzes = await this._quizRepo.findByCategory(catObj.id);
+            const quizzes = await this._categoryRepo.getQuizzes(category);
             return quizzes;
         } catch (error) {
             console.log(error);

--- a/src/resolvers/quiz/QuizResolver.ts
+++ b/src/resolvers/quiz/QuizResolver.ts
@@ -82,33 +82,23 @@ export class QuizResolver {
     }
 
     @Query(() => Quiz)
-    async quizById(@Arg("id") id: number): Promise<Quiz | null> {
-        try {
-            const quiz = await this._quizRepo.findById(id);
-            if (!quiz) throw new ResourceNotFound("Quiz does not exist");
-            return quiz;
-        } catch (error) {
-            if (error instanceof ResourceNotFound) throw error;
-            else {
-                console.log(error);
-                throw new Error("Database Error");
-            }
-        }
+    async quizById(@Arg("id") id: number): Promise<Quiz> {
+        const quiz = await this._quizRepo.findById(id).catch((error) => {
+            console.log(error);
+            throw new Error("Database Error");
+        });
+        if (!quiz) throw new ResourceNotFound("Quiz does not exist");
+        return quiz;
     }
 
     @Query(() => Quiz)
     async quizByName(@Arg("name") name: string): Promise<Quiz> {
-        try {
-            const quiz = await this._quizRepo.findByName(name);
-            if (!quiz) throw new ResourceNotFound("Quiz does not exist");
-            return quiz;
-        } catch (error) {
-            if (error instanceof ResourceNotFound) throw error;
-            else {
-                console.log(error);
-                throw new Error("Database Error");
-            }
-        }
+        const quiz = await this._quizRepo.findByName(name).catch((error) => {
+            console.log(error);
+            throw new Error("Database Error");
+        });
+        if (!quiz) throw new ResourceNotFound("Quiz does not exist");
+        return quiz;
     }
 
     @Query(() => [Quiz])

--- a/src/resolvers/quiz/QuizResolver.ts
+++ b/src/resolvers/quiz/QuizResolver.ts
@@ -206,7 +206,7 @@ export class QuizResolver {
         @Root() quiz: Quiz
     ): Promise<Question[]> {
         try {
-            const questions = await context.questionsLoader.load(quiz.id);
+            const questions = await context.quizQuestionsLoader.load(quiz.id);
             return questions;
         } catch (error) {
             console.log(error);

--- a/src/types/TContext.ts
+++ b/src/types/TContext.ts
@@ -2,6 +2,7 @@ import { Request } from "express";
 import { IncomingHttpHeaders } from "http2";
 import { CategoryLoader } from "../data-loader/CategoryLoader";
 import { DifficultyLoader } from "../data-loader/DifficultyLoader";
+import { QuestionAnswersLoader } from "../data-loader/QuestionAnswersLoader";
 import { QuizLoader } from "../data-loader/QuizLoader";
 import { QuizQuestionsLoader } from "../data-loader/QuizQuestionsLoader";
 import { SubmissionAnswersLoader } from "../data-loader/SubmissionAnswersLoader";
@@ -20,6 +21,7 @@ export interface TContext extends Request {
     user: UserData;
     headers: MyHeader;
     userLoader: ReturnType<typeof UserLoader>;
+    questionAnswersLoader: ReturnType<typeof QuestionAnswersLoader>;
     quizLoader: ReturnType<typeof QuizLoader>;
     difficultyLoader: ReturnType<typeof DifficultyLoader>;
     categoryLoader: ReturnType<typeof CategoryLoader>;

--- a/src/types/TContext.ts
+++ b/src/types/TContext.ts
@@ -2,7 +2,9 @@ import { Request } from "express";
 import { IncomingHttpHeaders } from "http2";
 import { CategoryLoader } from "../data-loader/CategoryLoader";
 import { DifficultyLoader } from "../data-loader/DifficultyLoader";
-import { QuestionsLoader } from "../data-loader/QuestionsLoader";
+import { QuizLoader } from "../data-loader/QuizLoader";
+import { QuizQuestionsLoader } from "../data-loader/QuizQuestionsLoader";
+import { SubmissionAnswersLoader } from "../data-loader/SubmissionAnswersLoader";
 import { UserLoader } from "../data-loader/UserLoader";
 
 export interface MyHeader extends IncomingHttpHeaders {
@@ -18,7 +20,9 @@ export interface TContext extends Request {
     user: UserData;
     headers: MyHeader;
     userLoader: ReturnType<typeof UserLoader>;
+    quizLoader: ReturnType<typeof QuizLoader>;
     difficultyLoader: ReturnType<typeof DifficultyLoader>;
     categoryLoader: ReturnType<typeof CategoryLoader>;
-    questionsLoader: ReturnType<typeof QuestionsLoader>;
+    quizQuestionsLoader: ReturnType<typeof QuizQuestionsLoader>;
+    submissionAnswersLoader: ReturnType<typeof SubmissionAnswersLoader>;
 }

--- a/src/types/TContext.ts
+++ b/src/types/TContext.ts
@@ -6,6 +6,7 @@ import { QuestionAnswersLoader } from "../data-loader/QuestionAnswersLoader";
 import { QuizLoader } from "../data-loader/QuizLoader";
 import { QuizQuestionsLoader } from "../data-loader/QuizQuestionsLoader";
 import { SubmissionAnswersLoader } from "../data-loader/SubmissionAnswersLoader";
+import { SubmissionScoreLoader } from "../data-loader/SubmissionScoreLoader";
 import { UserLoader } from "../data-loader/UserLoader";
 
 export interface MyHeader extends IncomingHttpHeaders {
@@ -27,4 +28,5 @@ export interface TContext extends Request {
     categoryLoader: ReturnType<typeof CategoryLoader>;
     quizQuestionsLoader: ReturnType<typeof QuizQuestionsLoader>;
     submissionAnswersLoader: ReturnType<typeof SubmissionAnswersLoader>;
+    submissionScoreLoader: ReturnType<typeof SubmissionScoreLoader>;
 }

--- a/src/types/TContext.ts
+++ b/src/types/TContext.ts
@@ -1,5 +1,9 @@
 import { Request } from "express";
 import { IncomingHttpHeaders } from "http2";
+import { CategoryLoader } from "../data-loader/CategoryLoader";
+import { DifficultyLoader } from "../data-loader/DifficultyLoader";
+import { QuestionsLoader } from "../data-loader/QuestionsLoader";
+import { UserLoader } from "../data-loader/UserLoader";
 
 export interface MyHeader extends IncomingHttpHeaders {
     authorization: string;
@@ -13,4 +17,8 @@ export interface UserData {
 export interface TContext extends Request {
     user: UserData;
     headers: MyHeader;
+    userLoader: ReturnType<typeof UserLoader>;
+    difficultyLoader: ReturnType<typeof DifficultyLoader>;
+    categoryLoader: ReturnType<typeof CategoryLoader>;
+    questionsLoader: ReturnType<typeof QuestionsLoader>;
 }


### PR DESCRIPTION
Initial Issue: Eager Loading fetches many data that are not used by all queries.

Initial Solution: Use Field Resolver instead of Eager Loading
=> Drawback of this approach: Make too many requests to the database
=> Improvement to this approach: Use DataLoader to cache all ids and make one request that will obtain all necessary data.